### PR TITLE
patch: publish medusa core as nelo npm github package

### DIFF
--- a/packages/medusa/package.json
+++ b/packages/medusa/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "@medusajs/medusa",
+  "name": "@nelo/medusa",
   "version": "1.20.7",
   "description": "Building blocks for digital commerce",
   "main": "dist/index.js",
   "bin": "./cli.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/medusajs/medusa",
+    "url": "https://github.com/nelo/medusa",
     "directory": "packages/medusa"
   },
   "publishConfig": {
-    "access": "public"
+    "registry": "https://npm.pkg.github.com"
   },
   "files": [
     "dist",

--- a/packages/medusa/package.json
+++ b/packages/medusa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nelo/medusa",
-  "version": "1.20.7",
+  "version": "1.20.7-patch.1",
   "description": "Building blocks for digital commerce",
   "main": "dist/index.js",
   "bin": "./cli.js",
@@ -10,6 +10,7 @@
     "directory": "packages/medusa"
   },
   "publishConfig": {
+    "access": "public",
     "registry": "https://npm.pkg.github.com"
   },
   "files": [

--- a/packages/medusa/package.json
+++ b/packages/medusa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nelo/medusa",
-  "version": "1.20.7-patch.1",
+  "version": "1.20.7-patch.2",
   "description": "Building blocks for digital commerce",
   "main": "dist/index.js",
   "bin": "./cli.js",


### PR DESCRIPTION
Base work for MKT-1295

here is the published package: https://github.com/nelo/medusa/pkgs/npm/medusa